### PR TITLE
Add the index_events property to the type for content list

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -144,6 +144,9 @@ export interface IPathway {
       stages: {
         [key: string]: IPathwayStageContent[];
       };
+      index_events: {
+        [key: string]: IPathwayStageContent[];
+      };
     };
   };
   currentStageSlug: string;
@@ -170,6 +173,9 @@ export interface IPathwayRaw {
     is_deleted: boolean;
     content_list: {
       stages: {
+        [key: string]: IPathwayStageContentRaw[];
+      };
+      index_events: {
         [key: string]: IPathwayStageContentRaw[];
       };
     };


### PR DESCRIPTION
The data is already included in the API response this simply
amends the type so that it is exposed to users of the client.